### PR TITLE
use hex notation

### DIFF
--- a/draft-ietf-tls-padding.xml
+++ b/draft-ietf-tls-padding.xml
@@ -57,7 +57,7 @@
       </figure>
 
       <t>
-        The <spanx style="verb">extension_data</spanx> for the extension consists of an arbitary number of zero bytes. For example, the smallest <spanx style="verb">padding</spanx> extension is four bytes long and is encoded as 00 15 00 00. A ten byte extension would include 6 bytes of <spanx style="verb">extension_data</spanx> and would be encoded as:
+        The <spanx style="verb">extension_data</spanx> for the extension consists of an arbitary number of zero bytes. For example, the smallest <spanx style="verb">padding</spanx> extension is four bytes long and is encoded as 0x00 0x15 0x00 0x00. A ten byte extension would include 6 bytes of <spanx style="verb">extension_data</spanx> and would be encoded as:
       </t>
 
       <figure>


### PR DESCRIPTION
Another trivial editorial suggestion. On initial read I paused for a second to consider why the code point was listed as 21 above yet 15 here. Obviously it's in hex; adding the "0x" when writing inline makes it explicit. I doubt any implementer would make a mistake here, but it makes it more clear nonetheless.
